### PR TITLE
fixing overflow on 32bit platforms + forach/dopar error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: r
 # see also https://docs.travis-ci.com/user/languages/r
 
+# see also https://docs.travis-ci.com/user/multi-os/
+os:
+  - linux
+  - osx
+
 # Using the package cache to store R package dependencies can significantly
 # speed up build times and is recommended for most builds.
 cache:

--- a/src/rcpp_wt_bases_paul.cpp
+++ b/src/rcpp_wt_bases_paul.cpp
@@ -24,7 +24,7 @@ const double map_m_to_ffact[] = {
 // Used the following R code to generate:
 // options(scipen = 999)
 // cat(sapply(0:10, function(m) prod(2:(2 * m - 1)) ), sep = ",\n")
-const long map_m_to_prod[] = {
+const uint64_t map_m_to_prod[] = {
   0,                    // m = 0
   2,                    // m = 1
   6,                    // m = 2
@@ -83,7 +83,7 @@ List rcpp_wt_bases_paul(const NumericVector k,
   //   prod *= i;
   // }
   // ... but we can precompute the values in a table map_m_to_prod
-  const long prod = map_m_to_prod[m]; // only works for m = 0..10
+  const uint64_t prod = map_m_to_prod[m]; // only works for m = 0..10
 
   // R: sqrt(scale * k[2]) * sqrt(length(k)) * (2^m) / sqrt(m * prod(2:(2 * m - 1)))
   // Note: k[2] in R is k[1] in c++ because vectors are indexed from 0

--- a/src/rcpp_wt_bases_paul.cpp
+++ b/src/rcpp_wt_bases_paul.cpp
@@ -24,7 +24,7 @@ const double map_m_to_ffact[] = {
 // Used the following R code to generate:
 // options(scipen = 999)
 // cat(sapply(0:10, function(m) prod(2:(2 * m - 1)) ), sep = ",\n")
-const uint64_t map_m_to_prod[] = {
+const unsigned long long map_m_to_prod[] = {
   0,                    // m = 0
   2,                    // m = 1
   6,                    // m = 2
@@ -83,7 +83,7 @@ List rcpp_wt_bases_paul(const NumericVector k,
   //   prod *= i;
   // }
   // ... but we can precompute the values in a table map_m_to_prod
-  const uint64_t prod = map_m_to_prod[m]; // only works for m = 0..10
+  const unsigned long long prod = map_m_to_prod[m]; // only works for m = 0..10
 
   // R: sqrt(scale * k[2]) * sqrt(length(k)) * (2^m) / sqrt(m * prod(2:(2 * m - 1)))
   // Note: k[2] in R is k[1] in c++ because vectors are indexed from 0

--- a/tests/testthat/test-wtc_sig_parallel.R
+++ b/tests/testthat/test-wtc_sig_parallel.R
@@ -2,6 +2,8 @@ context("Parallelized significance of wavelet coherence")
 
 # Setup variables =====
 
+foreach::registerDoSEQ() # to avoid warning when calling %dopar%
+
 size <- 64
 d1 <- cbind(1:size, rnorm(size))
 d2 <- cbind(1:size, rnorm(size))


### PR DESCRIPTION
- fixed issue #46 (overflow in 32bit platforms)
- fixed issue #45 using `foreach::registerDoSEQ()`
- added support for multi-os build on Travis (linux and osx) 
