### PR TITLE
define STRICT_R_HEADERS and use M_PI

### DIFF
--- a/src/rcpp_row_quantile.cpp
+++ b/src/rcpp_row_quantile.cpp
@@ -1,3 +1,4 @@
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 using namespace Rcpp;
 

--- a/src/rcpp_wt_bases_dog.cpp
+++ b/src/rcpp_wt_bases_dog.cpp
@@ -1,3 +1,4 @@
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 using namespace Rcpp;
 

--- a/src/rcpp_wt_bases_morlet.cpp
+++ b/src/rcpp_wt_bases_morlet.cpp
@@ -1,7 +1,8 @@
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 using namespace Rcpp;
 
-const double POWPI14 = pow(PI, -0.25);
+const double POWPI14 = pow(M_PI, -0.25);
 const double SQRT_ONE_HALF = sqrt(.5); // NOTE: sqrt(1/2) = 1/sqrt(2)
 
 // Used the following R code to generate:

--- a/src/rcpp_wt_bases_paul.cpp
+++ b/src/rcpp_wt_bases_paul.cpp
@@ -1,3 +1,4 @@
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 
 using namespace Rcpp;


### PR DESCRIPTION
Dear Tarik, Dear biwavelet team,

Your CRAN package biwavelet uses Rcpp, and is affected if we add a definition of STRICT_R_HEADERS as we would like to do. Please see the discussion at
   https://github.com/RcppCore/Rcpp/issues/1158  
and the links therein for more context on this.

Here, I prefixed each #include <Rcpp.h> with STRICT_R_HEADERS which is slightly more extensive then we need to, but it ensures we will not get surprised later. If you prefer, we can remove this in the PR. The one change that is needed is the change from PI to M_PI.

It would be lovely if you could apply this. There is no strong urgency: we aim to get this done over all affected packages in the space of a few months. If you apply it, would you mind dropping me a note by email or swinging by
   https://github.com/RcppCore/Rcpp/issues/1158  
to confirm?

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.